### PR TITLE
Send prefix in quotes

### DIFF
--- a/company-wordfreq.el
+++ b/company-wordfreq.el
@@ -100,8 +100,8 @@ A warning is issued if it can't be found on loading."
   "Fetches the candidates."
   (split-string (shell-command-to-string (concat
 					  (executable-find "rg")
-					  " -i -N ^" prefix " " (company-wordfreq--dictionary)))
-		"\n"))
+					  " -i -N \"^" prefix "\" " (company-wordfreq--dictionary)))
+		        "\n"))
 
 ;;;###autoload
 (defun company-wordfreq (command &optional arg &rest ignored)

--- a/test/company-wordfreq.el-test.el
+++ b/test/company-wordfreq.el-test.el
@@ -13,7 +13,7 @@
   (mocker-let ((executable-find (executable) ((:input '("rg") :output "/path/to/rg")))
 	       (shell-command-to-string (command)
 					((:input
-					  '("/path/to/rg -i -N ^foo /path/to/dict.txt")
+					  '("/path/to/rg -i -N \"^foo\" /path/to/dict.txt")
 					  :output "foobar\nfoobaz\nfoo")))
 	       (company-wordfreq--dictionary () ((:output "/path/to/dict.txt"))))
       (should (equal (company-wordfreq--candidates "foo") '("foobar" "foobaz" "foo")))))
@@ -22,7 +22,7 @@
   (mocker-let ((executable-find (executable) ((:input '("rg") :output "/path/to/rg")))
 	       (shell-command-to-string (command)
 					((:input
-					  '("/path/to/rg -i -N ^Foo /path/to/dict.txt")
+					  '("/path/to/rg -i -N \"^Foo\" /path/to/dict.txt")
 					  :output "foobar\nfoobaz\nfoo")))
 	       (company-wordfreq--dictionary () ((:output "/path/to/dict.txt"))))
       (should (equal (company-wordfreq--candidates "Foo") '("foobar" "foobaz" "foo")))))
@@ -31,7 +31,7 @@
   (mocker-let ((executable-find (executable) ((:input '("rg") :output "/other/path/to/rg")))
 	       (shell-command-to-string (command)
 					((:input
-					  '("/other/path/to/rg -i -N ^bar /other/path/to/dict.txt")
+					  '("/other/path/to/rg -i -N \"^bar\" /other/path/to/dict.txt")
 					  :output "barbar\nbarbaz\nbar")))
 	       (company-wordfreq--dictionary () ((:output "/other/path/to/dict.txt"))))
       (should (equal (company-wordfreq--candidates "bar") '("barbar" "barbaz" "bar")))))


### PR DESCRIPTION
This solves #1.

It turns out problem caused by fish shell. `/usr/bin/rg -i -N ^real ~/.emacs.d/wordfreq-dicts/english.txt` is valid in bash but not valid in fish shell. So I changed it to `/usr/bin/rg -i -N "^real" ~/.emacs.d/wordfreq-dicts/english.txt` which is valid for both.